### PR TITLE
fix: using environment variables to run acceptance tests

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -3,4 +3,4 @@ default: testacc
 # Run acceptance tests
 .PHONY: testacc
 testacc:
-	TF_ACC=1 go test ./... -v $(TESTARGS) -timeout 120m
+	TF_ACC=1 DEBUG_HTTP=0 go test ./... -v $(TESTARGS) -timeout 120m

--- a/internal/eva/client.go
+++ b/internal/eva/client.go
@@ -13,13 +13,13 @@ type Client struct {
 	restClient *resty.Client
 }
 
-func NewClient(apiURL string) *Client {
+func NewClient(apiURL string, debugMode bool) *Client {
 
 	restClient := resty.New().
 		SetBaseURL(apiURL).
 		SetHeader("Content-Type", contentType).
 		SetHeader("EVA-User-Agent", userAgent).
-		SetDebug(true)
+		SetDebug(debugMode)
 
 	return &Client{
 		restClient: restClient,

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -18,7 +19,10 @@ var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServe
 }
 
 func testAccPreCheck(t *testing.T) {
-	// You can add code here to run prior to any test case execution, for example assertions
-	// about the appropriate environment variables being set are common to see in a pre-check
-	// function.
+	if v := os.Getenv("EVA_API_URL_TEST_ACC"); v == "" {
+		t.Fatal("EVA_API_URL_TEST_ACC must be set for acceptance tests")
+	}
+	if v := os.Getenv("EVA_API_TOKEN_TEST_ACC"); v == "" {
+		t.Fatal("EVA_API_TOKEN_TEST_ACC must be set for acceptance tests")
+	}
 }


### PR DESCRIPTION
This PR contains a solution for running acceptance tests, we need a way to configure the provider when running tests.

The solution proposed in this PR checks the value of the `version` attribute inside the provider to know if it should fetch the provider configuration from environment variables or from client input values.

