### PR TITLE
fix: using env vars as fallback to configuration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,6 @@ jobs:
 
   # Run acceptance tests in a matrix with Terraform CLI versions
   test:
-    if: false
     name: Terraform Provider Acceptance Tests
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,10 +6,10 @@ name: Tests
 on:
   pull_request:
     paths-ignore:
-      - 'README.md'
+      - "README.md"
   push:
     paths-ignore:
-      - 'README.md'
+      - "README.md"
 
 # Testing only needs permissions to read the repository contents.
 permissions:
@@ -19,7 +19,7 @@ permissions:
 env:
   # Go language version to use for building. This value should also be updated
   # in the release workflow if changed.
-  GO_VERSION: '1.17'
+  GO_VERSION: "1.17"
 
 jobs:
   # Ensure project builds before running testing matrix
@@ -46,8 +46,8 @@ jobs:
       matrix:
         # list whatever Terraform versions here you would like to support
         terraform:
-          - '1.0.*'
-          - '1.1.*'
+          - "1.0.*"
+          - "1.1.*"
     steps:
       - uses: actions/setup-go@v2
         with:
@@ -60,5 +60,7 @@ jobs:
       - run: go mod download
       - env:
           TF_ACC: "1"
+          EVA_API_URL: "temp-value"
+          EVA_API_TOKEN: "temp-value"
         run: go test -v -cover ./internal/provider/
         timeout-minutes: 10

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -64,7 +64,7 @@ func (p *provider) Configure(ctx context.Context, req tfsdk.ConfigureProviderReq
 
 	p.evaClient = *eva.NewClient(data.Endpoint.Value)
 
-	if !data.Token.Null {
+	if data.Token.Value != "" {
 		p.evaClient.SetAuthorizationHeader(data.Token.Value)
 	} else {
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -33,7 +34,6 @@ type providerData struct {
 }
 
 func (p *provider) Configure(ctx context.Context, req tfsdk.ConfigureProviderRequest, resp *tfsdk.ConfigureProviderResponse) {
-
 	var data providerData
 	diags := req.Config.Get(ctx, &data)
 	resp.Diagnostics.Append(diags...)
@@ -42,7 +42,22 @@ func (p *provider) Configure(ctx context.Context, req tfsdk.ConfigureProviderReq
 		return
 	}
 
-	if data.Token.Null && (data.Username.Null || data.Password.Null) {
+	// if unset, fallback to env
+	if data.Endpoint.Null {
+		data.Endpoint.Value = os.Getenv("EVA_API_URL")
+	}
+
+	if data.Token.Null {
+		data.Token.Value = os.Getenv("EVA_API_TOKEN")
+	}
+
+	// required if still unset
+	if data.Endpoint.Value == "" {
+		resp.Diagnostics.AddError("No valid eva endpoint provided.", "A valid api endpoint is needed to authenticate on eva")
+		return
+	}
+
+	if data.Token.Value == "" && (data.Username.Null || data.Password.Null) {
 		resp.Diagnostics.AddError("No valid credentials provided.", "Both token and username/password are not filed. Please provide one of these.")
 		return
 	}
@@ -86,7 +101,7 @@ func (p *provider) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostic
 		Attributes: map[string]tfsdk.Attribute{
 			"endpoint": {
 				MarkdownDescription: "The base URL of the EVA API.",
-				Required:            true,
+				Optional:            true,
 				Type:                types.StringType,
 			},
 			"token": {

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -12,13 +13,16 @@ import (
 // CLI command executed to create a provider server to which the CLI can
 // reattach.
 var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){
-	"scaffolding": func() (tfprotov6.ProviderServer, error) {
+	"eva": func() (tfprotov6.ProviderServer, error) {
 		return tfsdk.NewProtocol6Server(New("test")()), nil
 	},
 }
 
 func testAccPreCheck(t *testing.T) {
-	// You can add code here to run prior to any test case execution, for example assertions
-	// about the appropriate environment variables being set are common to see in a pre-check
-	// function.
+	if v := os.Getenv("EVA_API_URL"); v == "" {
+		t.Fatal("EVA_API_URL must be set for acceptance tests")
+	}
+	if v := os.Getenv("EVA_API_TOKEN"); v == "" {
+		t.Fatal("EVA_API_TOKEN must be set for acceptance tests")
+	}
 }


### PR DESCRIPTION
This PR contains a solution for running acceptance tests, we need a way to configure the provider when running tests.

Using environment variables as a fallback for configuration input solves the problem