### PR TITLE
Fix: Verify if address is not-null when checking current state of a OU

### DIFF
--- a/internal/eva/client.go
+++ b/internal/eva/client.go
@@ -1,7 +1,13 @@
 package eva
 
 import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
 	"github.com/go-resty/resty/v2"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 const (
@@ -28,4 +34,30 @@ func NewClient(apiURL string) *Client {
 
 func (c *Client) SetAuthorizationHeader(token string) {
 	c.restClient.SetHeader("authorization", token)
+}
+
+func (c *Client) Post(ctx context.Context, url string, requestBody interface{}, responseBody *interface{}) error {
+	resp, err := c.restClient.R().
+		SetBody(requestBody).
+		Post(url)
+
+	if err != nil {
+		tflog.Error(ctx, "An network error ocurred.", err)
+
+		return err
+	}
+
+	if resp.StatusCode() != 200 {
+		tflog.Info(ctx, "Request failed", "Status code", resp.StatusCode(), "body", resp.String())
+
+		return errors.New(fmt.Sprintf("Request failed with error: %s", resp.String()))
+	}
+
+	var jsonResp CreateAccountingRecipeResponse
+	if err := json.Unmarshal([]byte(resp.Body()), &responseBody); err != nil || jsonResp.HasErrors {
+
+		return errors.New(fmt.Sprintf("Response could not be parsed. Received: %s", resp.String()))
+	}
+
+	return nil
 }

--- a/internal/eva/client.go
+++ b/internal/eva/client.go
@@ -1,13 +1,7 @@
 package eva
 
 import (
-	"context"
-	"encoding/json"
-	"errors"
-	"fmt"
-
 	"github.com/go-resty/resty/v2"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 const (
@@ -34,30 +28,4 @@ func NewClient(apiURL string) *Client {
 
 func (c *Client) SetAuthorizationHeader(token string) {
 	c.restClient.SetHeader("authorization", token)
-}
-
-func (c *Client) Post(ctx context.Context, url string, requestBody interface{}, responseBody *interface{}) error {
-	resp, err := c.restClient.R().
-		SetBody(requestBody).
-		Post(url)
-
-	if err != nil {
-		tflog.Error(ctx, "An network error ocurred.", err)
-
-		return err
-	}
-
-	if resp.StatusCode() != 200 {
-		tflog.Info(ctx, "Request failed", "Status code", resp.StatusCode(), "body", resp.String())
-
-		return errors.New(fmt.Sprintf("Request failed with error: %s", resp.String()))
-	}
-
-	var jsonResp CreateAccountingRecipeResponse
-	if err := json.Unmarshal([]byte(resp.Body()), &responseBody); err != nil || jsonResp.HasErrors {
-
-		return errors.New(fmt.Sprintf("Response could not be parsed. Received: %s", resp.String()))
-	}
-
-	return nil
 }

--- a/internal/eva/organization_unit.go
+++ b/internal/eva/organization_unit.go
@@ -26,17 +26,17 @@ type Address struct {
 }
 
 type CreateOrganizationUnitRequest struct {
-	Name                string  `json:"Name,omitempty"`
-	PhoneNumber         string  `json:"PhoneNumber,omitempty"`
-	EmailAddress        string  `json:"EmailAddress,omitempty"`
-	ParentID            int64   `json:"ParentID,omitempty"`
-	CurrencyID          string  `json:"CurrencyID,omitempty"`
-	BackendID           string  `json:"BackendID,omitempty"`
-	CostPriceCurrencyID string  `json:"CostPriceCurrencyID,omitempty"`
-	Type                int64   `json:"Type,omitempty"`
-	Latitude            float64 `json:"Latitude,omitempty"`
-	Longitude           float64 `json:"Longitude,omitempty"`
-	Address             Address `json:"Address,omitempty"`
+	Name                string   `json:"Name,omitempty"`
+	PhoneNumber         string   `json:"PhoneNumber,omitempty"`
+	EmailAddress        string   `json:"EmailAddress,omitempty"`
+	ParentID            int64    `json:"ParentID,omitempty"`
+	CurrencyID          string   `json:"CurrencyID,omitempty"`
+	BackendID           string   `json:"BackendID,omitempty"`
+	CostPriceCurrencyID string   `json:"CostPriceCurrencyID,omitempty"`
+	Type                int64    `json:"Type,omitempty"`
+	Latitude            float64  `json:"Latitude,omitempty"`
+	Longitude           float64  `json:"Longitude,omitempty"`
+	Address             *Address `json:"Address,omitempty"`
 }
 
 type createOrganizationUnitRequest struct {
@@ -78,15 +78,15 @@ func (c *Client) CreateOrganizationUnit(ctx context.Context, req CreateOrganizat
 }
 
 type UpdateOrganizationUnitRequest struct {
-	ID                  int64   `json:"ID,omitempty"`
-	Name                string  `json:"Name,omitempty"`
-	PhoneNumber         string  `json:"PhoneNumber,omitempty"`
-	EmailAddress        string  `json:"EmailAddress,omitempty"`
-	CostPriceCurrencyID string  `json:"CostPriceCurrencyID,omitempty"`
-	Type                int64   `json:"Type,omitempty"`
-	Latitude            float64 `json:"Latitude,omitempty"`
-	Longitude           float64 `json:"Longitude,omitempty"`
-	Address             Address `json:"Address,omitempty"`
+	ID                  int64    `json:"ID,omitempty"`
+	Name                string   `json:"Name,omitempty"`
+	PhoneNumber         string   `json:"PhoneNumber,omitempty"`
+	EmailAddress        string   `json:"EmailAddress,omitempty"`
+	CostPriceCurrencyID string   `json:"CostPriceCurrencyID,omitempty"`
+	Type                int64    `json:"Type,omitempty"`
+	Latitude            float64  `json:"Latitude,omitempty"`
+	Longitude           float64  `json:"Longitude,omitempty"`
+	Address             *Address `json:"Address,omitempty"`
 }
 
 type UpdateOrganizationUnitResponse struct {

--- a/internal/eva/organization_unit.go
+++ b/internal/eva/organization_unit.go
@@ -123,18 +123,18 @@ type GetOrganizationUnitDetailedRequest struct {
 }
 
 type GetOrganizationUnitDetailedResponse struct {
-	ID                  int64   `json:"ID"`
-	Name                string  `json:"Name"`
-	PhoneNumber         string  `json:"PhoneNumber"`
-	EmailAddress        string  `json:"EmailAddress"`
-	ParentID            int64   `json:"ParentID"`
-	CurrencyID          string  `json:"CurrencyID"`
-	BackendID           string  `json:"BackendID"`
-	CostPriceCurrencyID string  `json:"CostPriceCurrencyID"`
-	Type                int64   `json:"Type"`
-	Latitude            float64 `json:"Latitude"`
-	Longitude           float64 `json:"Longitude"`
-	Address             Address `json:"Address"`
+	ID                  int64    `json:"ID"`
+	Name                string   `json:"Name"`
+	PhoneNumber         string   `json:"PhoneNumber"`
+	EmailAddress        string   `json:"EmailAddress"`
+	ParentID            int64    `json:"ParentID"`
+	CurrencyID          string   `json:"CurrencyID"`
+	BackendID           string   `json:"BackendID"`
+	CostPriceCurrencyID string   `json:"CostPriceCurrencyID"`
+	Type                int64    `json:"Type"`
+	Latitude            float64  `json:"Latitude"`
+	Longitude           float64  `json:"Longitude"`
+	Address             *Address `json:"Address,omitempty"`
 }
 
 func (c *Client) GetOrganizationUnitDetailed(ctx context.Context, req GetOrganizationUnitDetailedRequest) (*GetOrganizationUnitDetailedResponse, error) {

--- a/internal/provider/resource_eva_organization_unit.go
+++ b/internal/provider/resource_eva_organization_unit.go
@@ -157,7 +157,7 @@ type organizationUnitData struct {
 	CurrencyId   types.String `tfsdk:"currency_id"`
 	ParentId     types.Int64  `tfsdk:"parent_id"`
 	BackendId    types.String `tfsdk:"backend_id"`
-	Address      address      `tfsdk:"address"`
+	Address      *address     `tfsdk:"address"`
 	Type         types.Int64  `tfsdk:"type"`
 }
 
@@ -175,7 +175,7 @@ func (r organizationUnit) Create(ctx context.Context, req tfsdk.CreateResourceRe
 		return
 	}
 
-	client_resp, err := r.provider.evaClient.CreateOrganizationUnit(ctx, eva.CreateOrganizationUnitRequest{
+	var organizationUnitRequest = eva.CreateOrganizationUnitRequest{
 		Name:                data.Name.Value,
 		PhoneNumber:         data.PhoneNumber.Value,
 		BackendID:           data.BackendId.Value,
@@ -183,18 +183,24 @@ func (r organizationUnit) Create(ctx context.Context, req tfsdk.CreateResourceRe
 		ParentID:            data.ParentId.Value,
 		CurrencyID:          data.CurrencyId.Value,
 		CostPriceCurrencyID: data.CurrencyId.Value,
-		Latitude:            data.Address.Latitude,
-		Longitude:           data.Address.Longitude,
-		Address: eva.Address{
+		Type:                data.Type.Value,
+	}
+	// check if address input is not empty
+	if data.Address != nil {
+		organizationUnitRequest.Latitude = data.Address.Latitude
+		organizationUnitRequest.Longitude = data.Address.Longitude
+
+		organizationUnitRequest.Address = &eva.Address{
 			Address1:    data.Address.Address1,
 			Address2:    data.Address.Address2,
 			HouseNumber: data.Address.HouseNumber,
 			ZipCode:     data.Address.ZipCode,
 			City:        data.Address.City,
 			CountryID:   data.Address.CountryID,
-		},
-		Type: data.Type.Value,
-	})
+		}
+	}
+
+	client_resp, err := r.provider.evaClient.CreateOrganizationUnit(ctx, organizationUnitRequest)
 
 	if err != nil {
 		resp.Diagnostics.AddError("Creating organization unit failed.", fmt.Sprintf("Unable to create example, got error: %s", err))
@@ -235,7 +241,7 @@ func (r organizationUnit) Read(ctx context.Context, req tfsdk.ReadResourceReques
 	data.PhoneNumber = types.String{Value: client_resp.PhoneNumber}
 	data.Name = types.String{Value: client_resp.Name}
 	data.ParentId = types.Int64{Value: client_resp.ParentID}
-	data.Address = address{
+	data.Address = &address{
 		Address1:    client_resp.Address.Address1,
 		Address2:    client_resp.Address.Address2,
 		HouseNumber: client_resp.Address.HouseNumber,
@@ -261,24 +267,30 @@ func (r organizationUnit) Update(ctx context.Context, req tfsdk.UpdateResourceRe
 		return
 	}
 
-	_, err := r.provider.evaClient.UpdateOrganizationUnit(ctx, eva.UpdateOrganizationUnitRequest{
+	var organizationUnitRequest = eva.UpdateOrganizationUnitRequest{
 		ID:                  data.Id.Value,
 		Name:                data.Name.Value,
 		PhoneNumber:         data.PhoneNumber.Value,
 		EmailAddress:        data.EmailAddress.Value,
 		CostPriceCurrencyID: data.CurrencyId.Value,
-		Latitude:            data.Address.Latitude,
-		Longitude:           data.Address.Longitude,
-		Address: eva.Address{
+		Type:                data.Type.Value,
+	}
+	// check if address input is not empty
+	if data.Address != nil {
+		organizationUnitRequest.Latitude = data.Address.Latitude
+		organizationUnitRequest.Longitude = data.Address.Longitude
+
+		organizationUnitRequest.Address = &eva.Address{
 			Address1:    data.Address.Address1,
 			Address2:    data.Address.Address2,
 			HouseNumber: data.Address.HouseNumber,
 			ZipCode:     data.Address.ZipCode,
 			City:        data.Address.City,
 			CountryID:   data.Address.CountryID,
-		},
-		Type: data.Type.Value,
-	})
+		}
+	}
+
+	_, err := r.provider.evaClient.UpdateOrganizationUnit(ctx, organizationUnitRequest)
 
 	if err != nil {
 		resp.Diagnostics.AddError("Updating organization unit failed.", fmt.Sprintf("Unable to update OU, got error: %s", err))

--- a/internal/provider/resource_eva_organization_unit.go
+++ b/internal/provider/resource_eva_organization_unit.go
@@ -241,17 +241,20 @@ func (r organizationUnit) Read(ctx context.Context, req tfsdk.ReadResourceReques
 	data.PhoneNumber = types.String{Value: client_resp.PhoneNumber}
 	data.Name = types.String{Value: client_resp.Name}
 	data.ParentId = types.Int64{Value: client_resp.ParentID}
-	data.Address = &address{
-		Address1:    types.String{Value: client_resp.Address.Address1},
-		Address2:    types.String{Value: client_resp.Address.Address2},
-		HouseNumber: types.String{Value: client_resp.Address.HouseNumber},
-		ZipCode:     types.String{Value: client_resp.Address.ZipCode},
-		City:        types.String{Value: client_resp.Address.City},
-		CountryID:   types.String{Value: client_resp.Address.CountryID},
-		Latitude:    types.Float64{Value: client_resp.Latitude},
-		Longitude:   types.Float64{Value: client_resp.Longitude},
-	}
 	data.Type = types.Int64{Value: client_resp.Type}
+
+	if client_resp.Address != nil {
+		data.Address = &address{
+			Address1:    types.String{Value: client_resp.Address.Address1},
+			Address2:    types.String{Value: client_resp.Address.Address2},
+			HouseNumber: types.String{Value: client_resp.Address.HouseNumber},
+			ZipCode:     types.String{Value: client_resp.Address.ZipCode},
+			City:        types.String{Value: client_resp.Address.City},
+			CountryID:   types.String{Value: client_resp.Address.CountryID},
+			Latitude:    types.Float64{Value: client_resp.Latitude},
+			Longitude:   types.Float64{Value: client_resp.Longitude},
+		}
+	}
 
 	diags = resp.State.Set(ctx, &data)
 	resp.Diagnostics.Append(diags...)

--- a/internal/provider/resource_eva_organization_unit.go
+++ b/internal/provider/resource_eva_organization_unit.go
@@ -140,14 +140,14 @@ func (t organizationUnitType) NewResource(ctx context.Context, in tfsdk.Provider
 }
 
 type address struct {
-	Address1    string  `tfsdk:"address1"`
-	Address2    string  `tfsdk:"address2"`
-	HouseNumber string  `tfsdk:"house_number"`
-	ZipCode     string  `tfsdk:"zip_code"`
-	City        string  `tfsdk:"city"`
-	CountryID   string  `tfsdk:"country_id"`
-	Latitude    float64 `tfsdk:"latitude"`
-	Longitude   float64 `tfsdk:"longitude"`
+	Address1    types.String  `tfsdk:"address1"`
+	Address2    types.String  `tfsdk:"address2"`
+	HouseNumber types.String  `tfsdk:"house_number"`
+	ZipCode     types.String  `tfsdk:"zip_code"`
+	City        types.String  `tfsdk:"city"`
+	CountryID   types.String  `tfsdk:"country_id"`
+	Latitude    types.Float64 `tfsdk:"latitude"`
+	Longitude   types.Float64 `tfsdk:"longitude"`
 }
 type organizationUnitData struct {
 	Id           types.Int64  `tfsdk:"id"`
@@ -187,16 +187,16 @@ func (r organizationUnit) Create(ctx context.Context, req tfsdk.CreateResourceRe
 	}
 	// check if address input is not empty
 	if data.Address != nil {
-		organizationUnitRequest.Latitude = data.Address.Latitude
-		organizationUnitRequest.Longitude = data.Address.Longitude
+		organizationUnitRequest.Latitude = data.Address.Latitude.Value
+		organizationUnitRequest.Longitude = data.Address.Longitude.Value
 
 		organizationUnitRequest.Address = &eva.Address{
-			Address1:    data.Address.Address1,
-			Address2:    data.Address.Address2,
-			HouseNumber: data.Address.HouseNumber,
-			ZipCode:     data.Address.ZipCode,
-			City:        data.Address.City,
-			CountryID:   data.Address.CountryID,
+			Address1:    data.Address.Address1.Value,
+			Address2:    data.Address.Address2.Value,
+			HouseNumber: data.Address.HouseNumber.Value,
+			ZipCode:     data.Address.ZipCode.Value,
+			City:        data.Address.City.Value,
+			CountryID:   data.Address.CountryID.Value,
 		}
 	}
 
@@ -242,14 +242,14 @@ func (r organizationUnit) Read(ctx context.Context, req tfsdk.ReadResourceReques
 	data.Name = types.String{Value: client_resp.Name}
 	data.ParentId = types.Int64{Value: client_resp.ParentID}
 	data.Address = &address{
-		Address1:    client_resp.Address.Address1,
-		Address2:    client_resp.Address.Address2,
-		HouseNumber: client_resp.Address.HouseNumber,
-		ZipCode:     client_resp.Address.ZipCode,
-		City:        client_resp.Address.City,
-		CountryID:   client_resp.Address.CountryID,
-		Latitude:    client_resp.Latitude,
-		Longitude:   client_resp.Longitude,
+		Address1:    types.String{Value: client_resp.Address.Address1},
+		Address2:    types.String{Value: client_resp.Address.Address2},
+		HouseNumber: types.String{Value: client_resp.Address.HouseNumber},
+		ZipCode:     types.String{Value: client_resp.Address.ZipCode},
+		City:        types.String{Value: client_resp.Address.City},
+		CountryID:   types.String{Value: client_resp.Address.CountryID},
+		Latitude:    types.Float64{Value: client_resp.Latitude},
+		Longitude:   types.Float64{Value: client_resp.Longitude},
 	}
 	data.Type = types.Int64{Value: client_resp.Type}
 
@@ -277,16 +277,16 @@ func (r organizationUnit) Update(ctx context.Context, req tfsdk.UpdateResourceRe
 	}
 	// check if address input is not empty
 	if data.Address != nil {
-		organizationUnitRequest.Latitude = data.Address.Latitude
-		organizationUnitRequest.Longitude = data.Address.Longitude
+		organizationUnitRequest.Latitude = data.Address.Latitude.Value
+		organizationUnitRequest.Longitude = data.Address.Longitude.Value
 
 		organizationUnitRequest.Address = &eva.Address{
-			Address1:    data.Address.Address1,
-			Address2:    data.Address.Address2,
-			HouseNumber: data.Address.HouseNumber,
-			ZipCode:     data.Address.ZipCode,
-			City:        data.Address.City,
-			CountryID:   data.Address.CountryID,
+			Address1:    data.Address.Address1.Value,
+			Address2:    data.Address.Address2.Value,
+			HouseNumber: data.Address.HouseNumber.Value,
+			ZipCode:     data.Address.ZipCode.Value,
+			City:        data.Address.City.Value,
+			CountryID:   data.Address.CountryID.Value,
 		}
 	}
 


### PR DESCRIPTION
This PR implements a solution for `terraform plan` when address was not set in tf configuration. Previously we were not checking if the `address` was null when reading the current state of an OU causing the terraform to detect changes even when the data has not changed.