### PR TITLE
fix: default values in roles were not being used correctly

### DIFF
--- a/internal/provider/modifiers.go
+++ b/internal/provider/modifiers.go
@@ -38,9 +38,8 @@ func (m boolDefaultModifier) Modify(ctx context.Context, req tfsdk.ModifyAttribu
 		return
 	}
 
-	if !bool.Null {
-		return
+	if bool.Unknown {
+		resp.AttributePlan = types.Bool{Value: m.Default}
 	}
 
-	resp.AttributePlan = types.Bool{Value: m.Default}
 }

--- a/internal/provider/resource_eva_role.go
+++ b/internal/provider/resource_eva_role.go
@@ -132,7 +132,7 @@ func (s roleProviderTypeData) setListOfFunctionalities(scopedFunctionalities []e
 func (r role) Create(ctx context.Context, req tfsdk.CreateResourceRequest, resp *tfsdk.CreateResourceResponse) {
 	var data roleProviderTypeData
 
-	diags := req.Config.Get(ctx, &data)
+	diags := req.Plan.Get(ctx, &data)
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {


### PR DESCRIPTION
The TF code describes the `Config` as follow:
```
Config is the configuration the user supplied for the resource.
This configuration may contain unknown values if a user uses
interpolation or other functionality that would prevent Terraform
from knowing the value at request time.
```

This means that the moment we use modifiers to set the default value, this is no longer part of the `Config` attribute. When using the `Plan` attribute, this contains the full "desired" state of the resource, including any modifications made to it.