### PR TITLE
feature: order ledger types resource

### DIFF
--- a/examples/resources/eva_order_ledger_type.tf
+++ b/examples/resources/eva_order_ledger_type.tf
@@ -1,0 +1,4 @@
+resource "eva_order_ledger_type" "test" {
+    name        = "test"
+    description = "test description"
+}

--- a/internal/eva/order_ledger_type.go
+++ b/internal/eva/order_ledger_type.go
@@ -1,0 +1,156 @@
+package eva
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+const (
+	createOrderLedgerTypePath = "/api/core/management/CreateOrderLedgerType"
+	listOrderLedgerTypePath   = "/api/core/management/ListOrderLedgerTypes"
+	updateOrderLedgerTypePath = "/api/core/management/UpdateOrderLedgerType"
+	deleteOrderLedgerTypePath = "/api/core/management/DeleteOrderLedgerType"
+)
+
+type CreateOrderLedgerTypeRequest struct {
+	Name        string `json:"Name"`
+	Description string `json:"Description,omitempty"`
+}
+
+type CreateOrderLedgerTypeResponse struct {
+	ID int64
+}
+
+func (c *Client) CreateOrderLedgerType(ctx context.Context, req CreateOrderLedgerTypeRequest) (*CreateOrderLedgerTypeResponse, error) {
+	resp, err := c.restClient.R().
+		SetBody(req).
+		Post(createOrderLedgerTypePath)
+
+	if err != nil {
+		tflog.Error(ctx, "An network error ocurred.", err)
+
+		return nil, err
+	}
+
+	if resp.StatusCode() != 200 {
+		tflog.Info(ctx, "Request failed", "Status code", resp.StatusCode(), "body", resp.String())
+
+		return nil, errors.New(fmt.Sprintf("Request failed with error: %s", resp.String()))
+	}
+
+	var jsonResp CreateOrderLedgerTypeResponse
+	if err := json.Unmarshal([]byte(resp.Body()), &jsonResp); err != nil {
+
+		return nil, errors.New(fmt.Sprintf("Response could not be parsed. Received: %s", resp.String()))
+	}
+
+	return &jsonResp, nil
+}
+
+type OrderLedgerType struct {
+	ID          int64  `json:"ID"`
+	Name        string `json:"Name"`
+	Description string `json:"Description,omitempty"`
+}
+
+type ListOrderLedgerTypeResponse struct {
+	Result []OrderLedgerType `json:"OrderLedgerTypes"`
+}
+
+func (c *Client) ListOrderLedgerTypes(ctx context.Context) (*ListOrderLedgerTypeResponse, error) {
+	resp, err := c.restClient.R().
+		Post(listOrderLedgerTypePath)
+
+	if err != nil {
+		tflog.Error(ctx, "An network error ocurred.", err)
+
+		return nil, err
+	}
+
+	if resp.StatusCode() != 200 {
+		tflog.Info(ctx, "Request failed", "Status code", resp.StatusCode(), "body", resp.String())
+
+		return nil, errors.New("Request failed.")
+	}
+
+	tflog.Debug(ctx, "Request info", "Status code", resp.StatusCode(), "body", resp.String())
+
+	var jsonResp ListOrderLedgerTypeResponse
+	if err := json.Unmarshal([]byte(resp.Body()), &jsonResp); err != nil {
+		return nil, errors.New(fmt.Sprintf("Response could not be parsed. Received: %s", resp.String()))
+	}
+
+	return &jsonResp, nil
+}
+
+type UpdateOrderLedgerTypeRequest struct {
+	ID          int64  `json:"ID"`
+	Name        string `json:"Name"`
+	Description string `json:"Description"`
+}
+
+type UpdateOrderLedgerTypeResponse struct {
+}
+
+func (c *Client) UpdateOrderLedgerType(ctx context.Context, req UpdateOrderLedgerTypeRequest) (*UpdateOrderLedgerTypeResponse, error) {
+	resp, err := c.restClient.R().
+		SetBody(req).
+		Post(updateOrderLedgerTypePath)
+
+	if err != nil {
+		tflog.Error(ctx, "An network error ocurred.", err)
+
+		return nil, err
+	}
+
+	if resp.StatusCode() != 200 {
+		tflog.Info(ctx, "Request failed", "Status code", resp.StatusCode(), "body", resp.String())
+
+		return nil, errors.New(fmt.Sprintf("Request failed with error: %s", resp.String()))
+	}
+
+	var jsonResp UpdateOrderLedgerTypeResponse
+	if err := json.Unmarshal([]byte(resp.Body()), &jsonResp); err != nil {
+
+		return nil, errors.New(fmt.Sprintf("Response could not be parsed. Received: %s", resp.String()))
+	}
+
+	return &jsonResp, nil
+}
+
+type DeleteOrderLedgerTypeRequest struct {
+	ID int64 `json:"ID"`
+}
+
+type DeleteOrderLedgerTypeResponse struct {
+}
+
+func (c *Client) DeleteOrderLedgerType(ctx context.Context, req DeleteOrderLedgerTypeRequest) (*DeleteOrderLedgerTypeResponse, error) {
+	resp, err := c.restClient.R().
+		SetBody(req).
+		Post(deleteOrderLedgerTypePath)
+
+	if err != nil {
+		tflog.Error(ctx, "An network error ocurred.", err)
+
+		return nil, err
+	}
+
+	if resp.StatusCode() != 200 {
+		tflog.Info(ctx, "Request failed", "Status code", resp.StatusCode(), "body", resp.String())
+
+		return nil, errors.New(fmt.Sprintf("Request failed with error: %s", resp.String()))
+	}
+
+	var jsonResp DeleteOrderLedgerTypeResponse
+	if err := json.Unmarshal([]byte(resp.Body()), &jsonResp); err != nil {
+
+		return nil, errors.New(fmt.Sprintf("Response could not be parsed. Received: %s", resp.String()))
+	}
+
+	return &jsonResp, nil
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -78,6 +78,7 @@ func (p *provider) GetResources(ctx context.Context) (map[string]tfsdk.ResourceT
 		"eva_stencil":             stencilType{},
 		"eva_open_id_provider":    openIdProviderType{},
 		"eva_custom_order_status": customOrderStatusType{},
+		"eva_order_ledger_type":   orderLedgerTypeSchema{},
 	}, nil
 }
 

--- a/internal/provider/resource_eva_order_ledger_type.go
+++ b/internal/provider/resource_eva_order_ledger_type.go
@@ -1,0 +1,176 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+
+	"github.com/mad-it/terraform-provider-eva/internal/eva"
+)
+
+type orderLedgerTypeSchema struct{}
+
+func (t orderLedgerTypeSchema) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {
+	return tfsdk.Schema{
+		MarkdownDescription: "Eva order ledger type configuration.",
+
+		Attributes: map[string]tfsdk.Attribute{
+			"id": {
+				MarkdownDescription: "ID of the order ledger type.",
+				Computed:            true,
+				Type:                types.Int64Type,
+				PlanModifiers: tfsdk.AttributePlanModifiers{
+					tfsdk.UseStateForUnknown(),
+				},
+			},
+			"name": {
+				MarkdownDescription: "name of the type",
+				Required:            true,
+				Type:                types.StringType,
+			},
+			"description": {
+				MarkdownDescription: "description of the type.",
+				Required:            true,
+				Type:                types.StringType,
+			},
+		},
+	}, nil
+}
+func (t orderLedgerTypeSchema) NewResource(ctx context.Context, in tfsdk.Provider) (tfsdk.Resource, diag.Diagnostics) {
+	provider, diags := convertProviderType(in)
+
+	return orderLedgerType{
+		provider: provider,
+	}, diags
+}
+
+type orderLedgerTypeData struct {
+	ID          types.Int64 `tfsdk:"id"`
+	Name        string      `tfsdk:"name"`
+	Description string      `tfsdk:"description"`
+}
+
+type orderLedgerType struct {
+	provider provider
+}
+
+func (r orderLedgerType) Create(ctx context.Context, req tfsdk.CreateResourceRequest, resp *tfsdk.CreateResourceResponse) {
+	var data orderLedgerTypeData
+
+	diags := req.Plan.Get(ctx, &data)
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	clientResponse, err := r.provider.evaClient.CreateOrderLedgerType(ctx, eva.CreateOrderLedgerTypeRequest{
+		Name:        data.Name,
+		Description: data.Description,
+	})
+
+	if err != nil {
+		resp.Diagnostics.AddError("Creating order ledger type failed.", fmt.Sprintf("Unable to create order ledger type, got error: %s", err))
+		return
+	}
+
+	data.ID = types.Int64{Value: clientResponse.ID}
+
+	tflog.Trace(ctx, "Created a order ledger type.")
+
+	diags = resp.State.Set(ctx, &data)
+	resp.Diagnostics.Append(diags...)
+}
+
+func (r orderLedgerType) Read(ctx context.Context, req tfsdk.ReadResourceRequest, resp *tfsdk.ReadResourceResponse) {
+	var data orderLedgerTypeData
+
+	diags := req.State.Get(ctx, &data)
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	clientResponse, err := r.provider.evaClient.ListOrderLedgerTypes(ctx)
+
+	if err != nil {
+		resp.Diagnostics.AddError("Getting order ledger type data failed.", fmt.Sprintf("Unable to get order ledger type, got error: %s", err))
+		return
+	}
+
+	var orderLedgerTypeFound bool = false
+
+	for _, orderLedgerType := range clientResponse.Result {
+		if orderLedgerType.ID == data.ID.Value {
+			data.Name = orderLedgerType.Name
+			data.Description = orderLedgerType.Description
+			orderLedgerTypeFound = true
+			break
+		}
+	}
+
+	if !orderLedgerTypeFound {
+		resp.Diagnostics.AddError("Could not find order ledger type data.", fmt.Sprintf("Unable to get order ledger type with ID: %d", data.ID.Value))
+		return
+	}
+
+	diags = resp.State.Set(ctx, &data)
+	resp.Diagnostics.Append(diags...)
+}
+
+func (r orderLedgerType) Update(ctx context.Context, req tfsdk.UpdateResourceRequest, resp *tfsdk.UpdateResourceResponse) {
+	var data orderLedgerTypeData
+
+	diags := req.Plan.Get(ctx, &data)
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	_, err := r.provider.evaClient.UpdateOrderLedgerType(ctx, eva.UpdateOrderLedgerTypeRequest{
+		ID:          data.ID.Value,
+		Name:        data.Name,
+		Description: data.Description,
+	})
+
+	if err != nil {
+		resp.Diagnostics.AddError("Updating order ledger type failed.", fmt.Sprintf("Unable to update order ledger type, got error: %s", err))
+		return
+	}
+
+	diags = resp.State.Set(ctx, &data)
+	resp.Diagnostics.Append(diags...)
+}
+
+func (r orderLedgerType) Delete(ctx context.Context, req tfsdk.DeleteResourceRequest, resp *tfsdk.DeleteResourceResponse) {
+	var data orderLedgerTypeData
+
+	diags := req.State.Get(ctx, &data)
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	_, err := r.provider.evaClient.DeleteOrderLedgerType(ctx, eva.DeleteOrderLedgerTypeRequest{
+		ID: data.ID.Value,
+	})
+
+	if err != nil {
+		resp.Diagnostics.AddError("Deleting order ledger type failed.", fmt.Sprintf("Unable to delete order ledger type, got error: %s", err))
+		return
+	}
+
+	resp.State.RemoveResource(ctx)
+}
+
+func (r orderLedgerType) ImportState(ctx context.Context, req tfsdk.ImportResourceStateRequest, resp *tfsdk.ImportResourceStateResponse) {
+	tfsdk.ResourceImportStatePassthroughID(ctx, tftypes.NewAttributePath().WithAttributeName("id"), req, resp)
+}

--- a/internal/provider/resource_eva_order_ledger_type_test.go
+++ b/internal/provider/resource_eva_order_ledger_type_test.go
@@ -1,0 +1,48 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccEvaOrderLedgerTypeResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testAccEvaOrderLedgerTypeResourceConfig("pending", "pending order"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("eva_order_ledger_type.test", "name", "pending"),
+					resource.TestCheckResourceAttr("eva_order_ledger_type.test", "description", "pending order"),
+				),
+			},
+			// // ImportState testing
+			// {
+			// 	ResourceName:      "eva_role.test",
+			// 	ImportState:       true,
+			// 	ImportStateVerify: true,
+			// },
+			// Update and Read testing
+			{
+				Config: testAccEvaCustomOrderStatusResourceConfig("completed", "completed order"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("eva_order_ledger_type.test", "name", "completed"),
+					resource.TestCheckResourceAttr("eva_order_ledger_type.test", "description", "completed order"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+func testAccEvaOrderLedgerTypeResourceConfig(name string, description string) string {
+	return fmt.Sprintf(`
+resource "eva_order_ledger_type" "test" {
+	name                   = "%s"
+	description            = "%s"
+}`, name, description)
+}

--- a/internal/provider/resource_eva_order_ledger_type_test.go
+++ b/internal/provider/resource_eva_order_ledger_type_test.go
@@ -22,13 +22,13 @@ func TestAccEvaOrderLedgerTypeResource(t *testing.T) {
 			},
 			// // ImportState testing
 			// {
-			// 	ResourceName:      "eva_role.test",
+			// 	ResourceName:      "eva_order_ledger_type.test",
 			// 	ImportState:       true,
 			// 	ImportStateVerify: true,
 			// },
 			// Update and Read testing
 			{
-				Config: testAccEvaCustomOrderStatusResourceConfig("completed", "completed order"),
+				Config: testAccEvaOrderLedgerTypeResourceConfig("completed", "completed order"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("eva_order_ledger_type.test", "name", "completed"),
 					resource.TestCheckResourceAttr("eva_order_ledger_type.test", "description", "completed order"),


### PR DESCRIPTION
This PR implements a new resource in our EVA TF provider `Order Ledger Types`.

The resource contains 2 attributes:

`name`: the name of the order ledger type (required)
`description`: the description of the order ledger type (required)

Example:

```
resource "eva_order_ledger_type" "test" {
    name        = "test"
    description = "test description"
}
```