### PR TITLE
feature: added cookbook account resource

### DIFF
--- a/examples/resources/eva_cookbook_account.tf
+++ b/examples/resources/eva_cookbook_account.tf
@@ -1,0 +1,6 @@
+resource "eva_cookbook_account" "example" {
+  name           = "My Example Cookbook Account"
+  object_account = "123" // Object account
+  booking_flags  = 1 // WithTaxInformation
+  type           = 1 // GeneralLedger
+}

--- a/internal/eva/cookbook_account.go
+++ b/internal/eva/cookbook_account.go
@@ -1,0 +1,152 @@
+package eva
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+const (
+	createCookbookAccountPath = "/api/core/management/CreateAccount"
+	getCookbookAccountPath    = "/api/core/management/GetAccount"
+	updateCookbookAccountPath = "/api/core/management/UpdateAccount"
+	deleteCookbookAccountPath = "/api/core/management/DeleteAccount"
+)
+
+type CreateCookbookAccountRequest struct {
+	Name          string `json:"Name"`
+	ObjectAccount string `json:"ObjectAccount"`
+	BookingFlags  int64  `json:"BookingFlags"`
+	Type          int64  `json:"Type"`
+}
+
+type CreateCookbookAccountResponse struct {
+	ID int64
+}
+
+func (c *Client) CreateCookbookAccount(ctx context.Context, req CreateCookbookAccountRequest) (*CreateCookbookAccountResponse, error) {
+	resp, err := c.restClient.R().
+		SetBody(req).
+		Post(createCookbookAccountPath)
+
+	if err != nil {
+		tflog.Error(ctx, "An network error ocurred.", err)
+
+		return nil, err
+	}
+
+	if resp.StatusCode() != 200 {
+		tflog.Info(ctx, "Request failed", "Status code", resp.StatusCode(), "body", resp.String())
+
+		return nil, errors.New(fmt.Sprintf("Request failed with error: %s", resp.String()))
+	}
+
+	var jsonResp CreateCookbookAccountResponse
+	if err := json.Unmarshal([]byte(resp.Body()), &jsonResp); err != nil {
+		return nil, errors.New(fmt.Sprintf("Response could not be parsed. Received: %s", resp.String()))
+	}
+
+	return &jsonResp, nil
+}
+
+type GetCookbookAccountRequest struct {
+	ID int64 `json:"ID"`
+}
+
+type GetCookbookAccountResponse struct {
+	ID            int64  `json:"ID"`
+	Name          string `json:"Name"`
+	ObjectAccount string `json:"ObjectAccount"`
+	BookingFlags  int64  `json:"BookingFlags"`
+	Type          int64  `json:"Type"`
+}
+
+func (c *Client) GetCookbookAccount(ctx context.Context, req GetCookbookAccountRequest) (*GetCookbookAccountResponse, error) {
+	resp, err := c.restClient.R().
+		SetBody(req).
+		Post(getCookbookAccountPath)
+
+	if err != nil {
+		tflog.Error(ctx, "An network error ocurred.", err)
+
+		return nil, err
+	}
+
+	if resp.StatusCode() != 200 {
+		tflog.Info(ctx, "Request failed", "Status code", resp.StatusCode(), "body", resp.String())
+
+		return nil, errors.New(fmt.Sprintf("Request failed with error: %s", resp.String()))
+	}
+
+	var jsonResp GetCookbookAccountResponse
+	if err := json.Unmarshal([]byte(resp.Body()), &jsonResp); err != nil {
+		return nil, errors.New(fmt.Sprintf("Response could not be parsed. Received: %s", resp.String()))
+	}
+
+	return &jsonResp, nil
+}
+
+type UpdateCookbookAccountRequest struct {
+	ID            int64  `json:"ID"`
+	Name          string `json:"Name"`
+	ObjectAccount string `json:"ObjectAccount"`
+	BookingFlags  int64  `json:"BookingFlags"`
+	Type          int64  `json:"Type"`
+}
+
+func (c *Client) UpdateCookbookAccount(ctx context.Context, req UpdateCookbookAccountRequest) (*EmptyResponse, error) {
+	resp, err := c.restClient.R().
+		SetBody(req).
+		Post(updateCookbookAccountPath)
+
+	if err != nil {
+		tflog.Error(ctx, "An network error ocurred.", err)
+
+		return nil, err
+	}
+
+	if resp.StatusCode() != 200 {
+		tflog.Info(ctx, "Request failed", "Status code", resp.StatusCode(), "body", resp.String())
+
+		return nil, errors.New(fmt.Sprintf("Request failed with error: %s", resp.String()))
+	}
+
+	var jsonResp EmptyResponse
+	if err := json.Unmarshal([]byte(resp.Body()), &jsonResp); err != nil {
+		return nil, errors.New(fmt.Sprintf("Response could not be parsed. Received: %s", resp.String()))
+	}
+
+	return &jsonResp, nil
+}
+
+type DeleteCookbookAccountRequest struct {
+	ID int64 `json:"ID"`
+}
+
+func (c *Client) DeleteCookbookAccount(ctx context.Context, req DeleteCookbookAccountRequest) (*EmptyResponse, error) {
+	resp, err := c.restClient.R().
+		SetBody(req).
+		Post(deleteCookbookAccountPath)
+
+	if err != nil {
+		tflog.Error(ctx, "An network error ocurred.", err)
+
+		return nil, err
+	}
+
+	if resp.StatusCode() != 200 {
+		tflog.Info(ctx, "Request failed", "Status code", resp.StatusCode(), "body", resp.String())
+
+		return nil, errors.New(fmt.Sprintf("Request failed with error: %s", resp.String()))
+	}
+
+	var jsonResp EmptyResponse
+	if err := json.Unmarshal([]byte(resp.Body()), &jsonResp); err != nil {
+		return nil, errors.New(fmt.Sprintf("Response could not be parsed. Received: %s", resp.String()))
+	}
+
+	return &jsonResp, nil
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -80,6 +80,7 @@ func (p *provider) GetResources(ctx context.Context) (map[string]tfsdk.ResourceT
 		"eva_custom_order_status": customOrderStatusType{},
 		"eva_employee":            employeeType{},
 		"eva_order_ledger_type":   orderLedgerTypeSchema{},
+		"eva_cookbook_account":    cookbookAccountType{},
 	}, nil
 }
 

--- a/internal/provider/resource_eva_cookbook_account.go
+++ b/internal/provider/resource_eva_cookbook_account.go
@@ -1,0 +1,195 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/mad-it/terraform-provider-eva/internal/eva"
+)
+
+type cookbookAccountType struct{}
+
+func (t cookbookAccountType) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {
+	return tfsdk.Schema{
+		MarkdownDescription: "Eva cookbook account configuration.",
+
+		Attributes: map[string]tfsdk.Attribute{
+			"id": {
+				MarkdownDescription: "ID of the cookbook account",
+				Computed:            true,
+				Type:                types.Int64Type,
+				PlanModifiers: tfsdk.AttributePlanModifiers{
+					tfsdk.UseStateForUnknown(),
+				},
+			},
+			"name": {
+				MarkdownDescription: "Name of the cookbook account",
+				Optional:            true,
+				Type:                types.StringType,
+			},
+			"object_account": {
+				MarkdownDescription: "?????",
+				Required:            true,
+				Type:                types.StringType,
+			},
+			"booking_flags": {
+				MarkdownDescription: `Booking flags for the cookbook account:
+				- None = 0,
+				- WithTaxInformation = 1,
+				- WithoutOffsets = 2,
+				- WithOrderNumber = 4,
+				- WithReference = 8,
+				- WithInvoiceNumber = 16,
+				- WithCurrencyInformation = 32
+				`,
+				Required: true,
+				Type:     types.Int64Type,
+			},
+			"type": {
+				MarkdownDescription: `Type of the cookbook account:
+				- GeneralLedger = 1,
+				- Debtor = 2,
+				- Creditor = 3
+				`,
+				Required: true,
+				Type:     types.Int64Type,
+			},
+		},
+	}, nil
+}
+
+func (t cookbookAccountType) NewResource(ctx context.Context, in tfsdk.Provider) (tfsdk.Resource, diag.Diagnostics) {
+	provider, diags := convertProviderType(in)
+
+	return cookbookAccount{
+		provider: provider,
+	}, diags
+}
+
+type cookbookAccountTypeData struct {
+	ID            types.Int64 `tfsdk:"id"`
+	Name          string      `tfsdk:"name"`
+	ObjectAccount string      `tfsdk:"object_account"`
+	BookingFlags  int64       `tfsdk:"booking_flags"`
+	Type          int64       `tfsdk:"type"`
+}
+
+type cookbookAccount struct {
+	provider provider
+}
+
+func (r cookbookAccount) Create(ctx context.Context, req tfsdk.CreateResourceRequest, resp *tfsdk.CreateResourceResponse) {
+	var data cookbookAccountTypeData
+
+	diags := req.Plan.Get(ctx, &data)
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	clientResponse, err := r.provider.evaClient.CreateCookbookAccount(ctx, eva.CreateCookbookAccountRequest{
+		Name:          data.Name,
+		ObjectAccount: data.ObjectAccount,
+		BookingFlags:  data.BookingFlags,
+		Type:          data.Type,
+	})
+
+	if err != nil {
+		resp.Diagnostics.AddError("Creating cookbook account failed.", fmt.Sprintf("Unable to create cookbook account, got error: %s", err))
+		return
+	}
+
+	data.ID = types.Int64{Value: clientResponse.ID}
+
+	tflog.Trace(ctx, "Created a cookbook account.")
+
+	diags = resp.State.Set(ctx, &data)
+	resp.Diagnostics.Append(diags...)
+}
+
+func (r cookbookAccount) Read(ctx context.Context, req tfsdk.ReadResourceRequest, resp *tfsdk.ReadResourceResponse) {
+	var data cookbookAccountTypeData
+
+	diags := req.State.Get(ctx, &data)
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	clientResponse, err := r.provider.evaClient.GetCookbookAccount(ctx, eva.GetCookbookAccountRequest{
+		ID: data.ID.Value,
+	})
+
+	if err != nil {
+		resp.Diagnostics.AddError("Getting cookbook account data failed.", fmt.Sprintf("Unable to get cookbook account, got error: %s", err))
+		return
+	}
+
+	data.Name = clientResponse.Name
+	data.ObjectAccount = clientResponse.ObjectAccount
+	data.BookingFlags = clientResponse.BookingFlags
+	data.Type = clientResponse.Type
+
+	diags = resp.State.Set(ctx, &data)
+	resp.Diagnostics.Append(diags...)
+}
+
+func (r cookbookAccount) Update(ctx context.Context, req tfsdk.UpdateResourceRequest, resp *tfsdk.UpdateResourceResponse) {
+	var data cookbookAccountTypeData
+
+	diags := req.Plan.Get(ctx, &data)
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	_, err := r.provider.evaClient.UpdateCookbookAccount(ctx, eva.UpdateCookbookAccountRequest{
+		ID:            data.ID.Value,
+		Name:          data.Name,
+		ObjectAccount: data.ObjectAccount,
+		BookingFlags:  data.BookingFlags,
+		Type:          data.Type,
+	})
+
+	if err != nil {
+		resp.Diagnostics.AddError("Updating cookbook account failed.", fmt.Sprintf("Unable to update cookbook account, got error: %s", err))
+		return
+	}
+
+	diags = resp.State.Set(ctx, &data)
+	resp.Diagnostics.Append(diags...)
+}
+
+func (r cookbookAccount) Delete(ctx context.Context, req tfsdk.DeleteResourceRequest, resp *tfsdk.DeleteResourceResponse) {
+	var data cookbookAccountTypeData
+
+	diags := req.State.Get(ctx, &data)
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	_, err := r.provider.evaClient.DeleteCookbookAccount(ctx, eva.DeleteCookbookAccountRequest{
+		ID: data.ID.Value,
+	})
+
+	if err != nil {
+		resp.Diagnostics.AddError("Deleting cookbook account failed.", fmt.Sprintf("Unable to delete cookbook account, got error: %s", err))
+		return
+	}
+
+	resp.State.RemoveResource(ctx)
+}
+
+func (r cookbookAccount) ImportState(ctx context.Context, req tfsdk.ImportResourceStateRequest, resp *tfsdk.ImportResourceStateResponse) {
+	tfsdk.ResourceImportStatePassthroughID(ctx, tftypes.NewAttributePath().WithAttributeName("id"), req, resp)
+}

--- a/internal/provider/resource_eva_cookbook_account_test.go
+++ b/internal/provider/resource_eva_cookbook_account_test.go
@@ -1,0 +1,54 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccEvaCookbookAccountResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testAccEvaCookbookAccountResourceConfig("cookbook account", "123", "1", "1"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("eva_cookbook_account.test", "name", "cookbook account"),
+					resource.TestCheckResourceAttr("eva_cookbook_account.test", "object_account", "123"),
+					resource.TestCheckResourceAttr("eva_cookbook_account.test", "booking_flags", "1"),
+					resource.TestCheckResourceAttr("eva_cookbook_account.test", "type", "1"),
+				),
+			},
+			// // ImportState testing
+			// {
+			// 	ResourceName:      "eva_role.test",
+			// 	ImportState:       true,
+			// 	ImportStateVerify: true,
+			// },
+			// Update and Read testing
+			{
+				Config: testAccEvaCookbookAccountResourceConfig("my account", "321", "2", "3"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("eva_cookbook_account.test", "name", "my account"),
+					resource.TestCheckResourceAttr("eva_cookbook_account.test", "object_account", "321"),
+					resource.TestCheckResourceAttr("eva_cookbook_account.test", "booking_flags", "2"),
+					resource.TestCheckResourceAttr("eva_cookbook_account.test", "type", "3"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+func testAccEvaCookbookAccountResourceConfig(name string, objectAccount string, bookingFlags string, accountType string) string {
+	return fmt.Sprintf(`
+resource "eva_cookbook_account" "test" {
+	name                   = "%s"
+	object_account         = "%s"
+	booking_flags          = %s
+	type                   = %s
+}`, name, objectAccount, bookingFlags, accountType)
+}


### PR DESCRIPTION
This PR implements a new resource in our EVA TF provider Cookbook Account (aka General Ledgers).

The resource contains 4 attributes:

`name`: the name of the account (required)
`object_account`: no idea what it means (required)
`booking_flags`: the booking flags for the account (
    None = 0,
    WithTaxInformation = 1,
    WithoutOffsets = 2,
    WithOrderNumber = 4,
    WithReference = 8,
    WithInvoiceNumber = 16,
    WithCurrencyInformation = 3 
)
`type`: the type of account (GeneralLedger = 1, Debtor = 2, Creditor = 3)

Example:

```
resource "eva_cookbook_account" "example" {
  name           = "My Example Cookbook Account"
  object_account = "123"
  booking_flags  = 2
  type           = 2
}
```